### PR TITLE
Update Swashbuckle to fix compatibility with >= 6.3.0

### DIFF
--- a/UnException/UnException.Swashbuckle.UnitTests/OperationFilters/ReplyOnExceptionOperationFilterTests.cs
+++ b/UnException/UnException.Swashbuckle.UnitTests/OperationFilters/ReplyOnExceptionOperationFilterTests.cs
@@ -53,7 +53,7 @@ namespace BanallyMe.UnException.Swashbuckle.UnitTests.OperationFilters
         {
             var fakeContext = new OperationFilterContext(null, schemaGenerator.Object, null, method);
             var fakeSchema = new OpenApiSchema();
-            schemaGenerator.Setup(gen => gen.GenerateSchema(typeof(string), fakeContext.SchemaRepository, null, null)).Returns(fakeSchema);
+            schemaGenerator.Setup(gen => gen.GenerateSchema(typeof(string), fakeContext.SchemaRepository, null, null, null)).Returns(fakeSchema);
             var fakeOperation = new OpenApiOperation { Responses = new OpenApiResponses() };
 
             var expectedResponseStatusCode = fakeReplyStatuscode.ToString(System.Globalization.CultureInfo.InvariantCulture);

--- a/UnException/UnException.Swashbuckle/UnException.Swashbuckle.csproj
+++ b/UnException/UnException.Swashbuckle/UnException.Swashbuckle.csproj
@@ -29,7 +29,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.4.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.3.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Hello as we upgrade to Swashbuckle > 6.3.0 we got some exceptions with your library.

```C#
Swashbuckle.AspNetCore.SwaggerGen.SwaggerGeneratorException: Failed to generate Operation for action - ########. See inner exception
 ---> System.MissingMethodException: Method not found: 'Microsoft.OpenApi.Models.OpenApiSchema Swashbuckle.AspNetCore.SwaggerGen.ISchemaGenerator.GenerateSchema(System.Type, Swashbuckle.AspNetCore.SwaggerGen.SchemaRepository, System.Reflection.MemberInfo, System.Reflection.ParameterInfo)'.
   at BanallyMe.UnException.Swashbuckle.OperationFilters.ReplyOnExceptionOperationFilter.OperationResponse.GetStringMediaTypeForContext(OperationFilterContext context)
   at BanallyMe.UnException.Swashbuckle.OperationFilters.ReplyOnExceptionOperationFilter.OperationResponse.FromReplyAttributeForContext(ReplyOnExceptionWithAttribute replyAttribute, OperationFilterContext context)
   at BanallyMe.UnException.Swashbuckle.OperationFilters.ReplyOnExceptionOperationFilter.AddAttributeSpecificationsToOperationInContext(ReplyOnExceptionWithAttribute attribute, OpenApiOperation operation, OperationFilterContext context)
   at BanallyMe.UnException.Swashbuckle.OperationFilters.ReplyOnExceptionOperationFilter.AddAutomaticRepliesToOperation(OpenApiOperation operation, OperationFilterContext context)
   at BanallyMe.UnException.Swashbuckle.OperationFilters.ReplyOnExceptionOperationFilter.Apply(OpenApiOperation operation, OperationFilterContext context)
   at Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenerator.GenerateOperation(ApiDescription apiDescription, SchemaRepository schemaRepository)
   --- End of inner exception stack trace ---
   at Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenerator.GenerateOperation(ApiDescription apiDescription, SchemaRepository schemaRepository)
   at Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenerator.GenerateOperations(IEnumerable`1 apiDescriptions, SchemaRepository schemaRepository)
   at Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenerator.GeneratePaths(IEnumerable`1 apiDescriptions, SchemaRepository schemaRepository)
   at Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenerator.GetSwagger(String documentName, String host, String basePath)
   at Swashbuckle.AspNetCore.Swagger.SwaggerMiddleware.Invoke(HttpContext httpContext, ISwaggerProvider swaggerProvider)
   at StackifyMiddleware.RequestTracerMiddleware.InvokeAsync(HttpContext context) in D:\a\1\s\StackifyMiddleware\RequestTracerMiddleware.cs:line 168
```
   
This is because the implementation of the `GenerateSchema` method has been changed. 
This PR fix the issue with updating Swashbuckle.
 